### PR TITLE
Pass SKALE_MANAGER_ADDRESS to deploy_ima_proxy function

### DIFF
--- a/deploy_test_ima.sh
+++ b/deploy_test_ima.sh
@@ -34,4 +34,5 @@ fi
 deploy_manager $MANAGER_TAG $DOCKER_NETWORK_ENDPOINT $ETH_PRIVATE_KEY $GAS_PRICE $NETWORK $ETHERSCAN
 echo "Copying $DIR/contracts_data/manager.json -> $DIR/contracts_data/skaleManagerComponents.json"
 cp $DIR/contracts_data/manager.json $DIR/contracts_data/skaleManagerComponents.json
-deploy_ima_proxy $IMA_TAG $DOCKER_NETWORK_ENDPOINT $ETH_PRIVATE_KEY $GAS_PRICE
+SKALE_MANAGER_ADDRESS=$(jq -r '.skale_manager_address' $DIR/contracts_data/manager.json)
+deploy_ima_proxy $IMA_TAG $DOCKER_NETWORK_ENDPOINT $ETH_PRIVATE_KEY $GAS_PRICE $SKALE_MANAGER_ADDRESS

--- a/helper.sh
+++ b/helper.sh
@@ -165,6 +165,7 @@ deploy_ima_proxy () {
     : "${2?Pass ENDPOINT to ${FUNCNAME[0]}}"
     : "${3?Pass ETH_PRIVATE_KEY to ${FUNCNAME[0]}}"
     : "${4?Pass GAS_PRICE to ${FUNCNAME[0]}}"
+    : "${5?Pass SKALE_MANAGER_ADDRESS to ${FUNCNAME[0]}}"
     echo Going to run $IMA_IMAGE_NAME:$1 docker container...
 
     mkdir -p $DIR/contracts_data/ima-openzeppelin
@@ -185,6 +186,7 @@ deploy_ima_proxy () {
         -e URL_W3_ETHEREUM=$2 \
         -e PRIVATE_KEY_FOR_ETHEREUM=$3 \
         -e GASPRICE=$4 \
+        -e SKALE_MANAGER_ADDRESS=$5 \
         -e NETWORK_FOR_ETHEREUM="mainnet" \
         skalenetwork/$IMA_IMAGE_NAME:$1 \
         bash -c "$cmd"


### PR DESCRIPTION
Latest versions of ima containers need skale-contracts alias to run, so this fix now identifies it from deployed test contracts and exports it as an environment variable.