### PR TITLE
Pass SKALE_MANAGER_ADDRESS to deploy_ima_proxy function in deploy_ima.sh

### DIFF
--- a/deploy_ima.sh
+++ b/deploy_ima.sh
@@ -22,4 +22,5 @@ fi
 source $DIR/helper.sh
 echo "Copying $DIR/contracts_data/manager.json -> $DIR/contracts_data/skaleManagerComponents.json"
 cp $DIR/contracts_data/manager.json $DIR/contracts_data/skaleManagerComponents.json
-deploy_ima_proxy $IMA_TAG $ENDPOINT $ETH_PRIVATE_KEY $GAS_PRICE
+SKALE_MANAGER_ADDRESS=$(jq -r '.skale_manager_address' $DIR/contracts_data/manager.json)
+deploy_ima_proxy $IMA_TAG $ENDPOINT $ETH_PRIVATE_KEY $GAS_PRICE $SKALE_MANAGER_ADDRESS


### PR DESCRIPTION
This pull request includes a change to the `deploy_ima.sh` script to enhance the deployment process by including an skale manager contract address, that skale-contracts needs.

Enhancements to deployment process:

* [`deploy_ima.sh`](diffhunk://#diff-bba6bf0188e9518221de0ad3e48cc8b144bfcb6b2bb864211f4b292787c58049L25-R26): Added `SKALE_MANAGER_ADDRESS` parameter to the `deploy_ima_proxy` command by extracting it from `manager.json` using `jq`.