### PR TITLE
Run sgx simulator only if it is not running

### DIFF
--- a/helper.sh
+++ b/helper.sh
@@ -249,11 +249,12 @@ run_anvil () {
 run_sgx_simulator () {
     : "${1?Pass SGX_WALLET_TAG to ${FUNCNAME[0]}}"
     SGX_WALLET_IMAGE_NAME=skalenetwork/sgxwallet_sim:$1
-
-    docker rm -f $SGX_WALLET_CONTAINER_NAME || true
-    docker pull $SGX_WALLET_IMAGE_NAME
-    docker run -d -p 1026-1031:1026-1031 --name $SGX_WALLET_CONTAINER_NAME $SGX_WALLET_IMAGE_NAME -s -y -a
+    if ! docker inspect "${container_name}" >/dev/null 2>&1; then
+        docker pull $SGX_WALLET_IMAGE_NAME
+        docker run -d -p 1026-1031:1026-1031 --name $SGX_WALLET_CONTAINER_NAME $SGX_WALLET_IMAGE_NAME -s -y
+    fi
 }
+
 
 
 create_test_docker_network () {


### PR DESCRIPTION
This pull request refines the `run_sgx_simulator` function in `helper.sh` to improve its robustness by ensuring the container is checked before attempting to pull and run it. The changes simplify the logic and prevent unnecessary operations.

Key improvements to container management:

* [`helper.sh`](diffhunk://#diff-9e8a09c6f7d7cdbf33a2716859fb318fb3145caece1dd98c361dfdfcc0ee537bL252-R259): Updated the `run_sgx_simulator` function to check if the container exists using `docker inspect` before pulling and running the image. This avoids forcefully removing the container and ensures operations are only performed when necessary.